### PR TITLE
Fix federation schema and export commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ COPY task_service/requirements.txt /app/task_service/requirements.txt
 COPY user_service/requirements.txt /app/user_service/requirements.txt
 RUN pip install --no-cache-dir -r task_service/requirements.txt && \
     pip install --no-cache-dir -r user_service/requirements.txt
+RUN strawberry export-schema user_service/schema/schema:schema > user_service/schema/schema.graphql
+RUN strawberry export-schema task_service/schema/schema:schema > task_service/schema/schema.graphql
 
 # Copy Node dependencies and install
 COPY gateway/package.json /app/gateway/package.json

--- a/task_service/Dockerfile
+++ b/task_service/Dockerfile
@@ -3,5 +3,6 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
+RUN strawberry export-schema schema.schema:schema > schema/schema.graphql
 EXPOSE 8800
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8800"]

--- a/task_service/schema/types.py
+++ b/task_service/schema/types.py
@@ -51,7 +51,7 @@ class User:
 
     @strawberry.federation.field(requires=["name"])
     def code(self) -> str:
-        return f"TaskService: {self.task_name}"
+        return f"TaskService: {self.name}"
 
     @strawberry.field
     async def tasks(self) -> List[Task]:

--- a/tests/test_dockerfiles.py
+++ b/tests/test_dockerfiles.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
+
+def _has_export_command(path):
+    if not os.path.isfile(path):
+        return False
+    with open(path) as f:
+        content = f.read()
+    return 'strawberry export-schema' in content
+
+
+class DockerfileTest(unittest.TestCase):
+    def test_user_service_dockerfile_has_export(self):
+        path = os.path.join(BASE_DIR, 'user_service', 'Dockerfile')
+        self.assertTrue(_has_export_command(path))
+
+    def test_task_service_dockerfile_has_export(self):
+        path = os.path.join(BASE_DIR, 'task_service', 'Dockerfile')
+        self.assertTrue(_has_export_command(path))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_schema_files.py
+++ b/tests/test_schema_files.py
@@ -1,0 +1,24 @@
+import os
+import unittest
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
+
+class SchemaFilesTest(unittest.TestCase):
+    def test_user_schema_exists(self):
+        path = os.path.join(BASE_DIR, 'user_service', 'schema', 'schema.graphql')
+        self.assertTrue(os.path.isfile(path))
+        with open(path) as f:
+            content = f.read()
+            self.assertIn('type User', content)
+
+    def test_task_schema_exists(self):
+        path = os.path.join(BASE_DIR, 'task_service', 'schema', 'schema.graphql')
+        self.assertTrue(os.path.isfile(path))
+        with open(path) as f:
+            content = f.read()
+            self.assertIn('type Task', content)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/user_service/Dockerfile
+++ b/user_service/Dockerfile
@@ -3,5 +3,6 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
+RUN strawberry export-schema schema.schema:schema > schema/schema.graphql
 EXPOSE 8000
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/user_service/schema/schema.py
+++ b/user_service/schema/schema.py
@@ -49,7 +49,7 @@ class Query:
 @strawberry.type
 class Mutation:
     @strawberry.mutation
-    async def create_user(self, name: str, email: str, cpf: str) -> User:
+    async def create_user(self, name: str, email: str, cpf: str) -> AddUserResponse:
         async with get_session() as s:
             existing_db_user = None
             sql = select(models.User).where(models.User.cpf == cpf)

--- a/user_service/schema/types.py
+++ b/user_service/schema/types.py
@@ -1,7 +1,5 @@
 import strawberry
 from models import models
-from sqlalchemy import select
-from typing import List, Optional
 
 
 @strawberry.federation.type(keys=["id"])
@@ -13,29 +11,12 @@ class User:
 
     @classmethod
     def marshal(cls, model: models.User) -> "User":
-        return cls(id=strawberry.ID(str(model.id)), name=model.name, email=model.email, cpf=model.cpf)
+        return cls(
+            id=strawberry.ID(str(model.id)),
+            name=model.name,
+            email=model.email,
+            cpf=model.cpf,
+        )
 
 
-@strawberry.federation.type(keys=["id"], extend=True)
-class Task:
-    id: strawberry.ID = strawberry.federation.field(external=True)
-    task_name: str = strawberry.federation.field(external=True)
 
-    @strawberry.federation.field(requires=["task_name"])
-    def code(self) -> str:
-        return f"TaskService: {self.task_name}"
-
-    @strawberry.field
-    async def tasks(self) -> List["Task"]:
-        if self.id:
-            async with models.get_session() as s:
-                sql = select(models.User).where(models.User.tasks == self.id)
-                db_tasks = (await s.execute(sql)).scalars().unique().all()
-            return [Task.marshal(tasks) for tasks in db_tasks]
-        else:
-            return []
-
-
-    @classmethod
-    async def resolve_reference(cls, id: strawberry.ID, task_name: Optional[str] = None):
-        return cls(id=id, task_name=task_name)


### PR DESCRIPTION
## Summary
- fix `User.code` method in task service
- fix `create_user` mutation return type
- simplify user service types
- export schema during Docker build
- add tests checking schema files and Dockerfiles

## Testing
- `python -m unittest discover -v tests`

------
https://chatgpt.com/codex/tasks/task_e_685f336a34dc83249129b6c8adca224e